### PR TITLE
multiple fixes in example folder and command improvement

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ local-config/
 
 # once gulp is run, this file is generated.  Some debate whether this should be checked in or not
 package-lock.json
+yarn.lock

--- a/apps/helloworld/springboot/Dockerfile
+++ b/apps/helloworld/springboot/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:8u131
+FROM openjdk:8u131-jre
 ENV JAVA_APP_JAR boot-demo-1.0.0.jar
 WORKDIR /app/
 COPY target/$JAVA_APP_JAR .

--- a/apps/helloworld/springboot/Dockerfile.openshift
+++ b/apps/helloworld/springboot/Dockerfile.openshift
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/redhat-openjdk-18/openjdk18-openshift
+FROM registry.access.redhat.com/ubi8/openjdk-8-runtime
 WORKDIR /work/
 ENV JAVA_APP_JAR boot-demo-1.0.0.jar
 # the following is not needed on this Red Hat created image

--- a/apps/helloworld/springboot/Dockerfile_Java11
+++ b/apps/helloworld/springboot/Dockerfile_Java11
@@ -1,4 +1,4 @@
-FROM openjdk:11
+FROM openjdk:11-jre
 ENV JAVA_APP_JAR boot-demo-1.0.0.jar
 WORKDIR /app/
 COPY target/$JAVA_APP_JAR .

--- a/apps/helloworld/springboot/Dockerfile_Memory
+++ b/apps/helloworld/springboot/Dockerfile_Memory
@@ -1,4 +1,4 @@
-FROM openjdk:8u151
+FROM openjdk:8u151-jre
 ENV JAVA_APP_JAR boot-demo-1.0.0.jar
 WORKDIR /app/
 COPY target/$JAVA_APP_JAR .

--- a/apps/helloworld/springboot/Dockerfile_Memory2
+++ b/apps/helloworld/springboot/Dockerfile_Memory2
@@ -1,4 +1,4 @@
-FROM openjdk:8
+FROM openjdk:8u131-jre
 ENV JAVA_APP_JAR boot-demo-1.0.0.jar
 WORKDIR /app/
 COPY target/$JAVA_APP_JAR .

--- a/documentation/modules/ROOT/examples/PizzaResourceWatcher.java
+++ b/documentation/modules/ROOT/examples/PizzaResourceWatcher.java
@@ -1,1 +1,61 @@
-/workspaces/kubernetes-tutorial/apps/pizza-operator/src/main/java/org/acme/PizzaResourceWatcher.java
+package org.acme;
+
+import io.fabric8.kubernetes.api.model.ContainerBuilder;
+import io.fabric8.kubernetes.api.model.ObjectMetaBuilder;
+import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.api.model.PodBuilder;
+import io.fabric8.kubernetes.api.model.PodSpecBuilder;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.KubernetesClientException;
+import io.fabric8.kubernetes.client.Watcher;
+import io.fabric8.kubernetes.client.dsl.NonNamespaceOperation;
+import io.fabric8.kubernetes.client.dsl.Resource;
+import io.quarkus.runtime.StartupEvent;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import javax.enterprise.event.Observes;
+import javax.inject.Inject;
+
+public class PizzaResourceWatcher {
+
+    @Inject
+    KubernetesClient defaultClient;
+
+    @Inject
+    NonNamespaceOperation<PizzaResource, PizzaResourceList, PizzaResourceDoneable, Resource<PizzaResource, PizzaResourceDoneable>> crClient;
+
+    void onStartup(@Observes StartupEvent event) {
+        System.out.println("Startup");
+        crClient.watch(new Watcher<PizzaResource>() { //<.>
+            @Override
+            public void eventReceived(Action action, PizzaResource resource) {
+                System.out.println("Event " + action.name());
+                if (action == Action.ADDED) {
+                    final String app = resource.getMetadata().getName();
+                    final String sauce = resource.getSpec().getSauce();
+                    final List<String> toppings = resource.getSpec().getToppings();
+                    final Map<String, String> labels = new HashMap<>();
+                    labels.put("app", app);
+                    final ObjectMetaBuilder objectMetaBuilder = new ObjectMetaBuilder().withName(app + "-pod")
+                            .withNamespace(resource.getMetadata().getNamespace()).withLabels(labels);
+                    final ContainerBuilder containerBuilder = new ContainerBuilder().withName("pizza-maker")
+                            .withImage("quay.io/lordofthejars/pizza-maker:1.0.0").withCommand("/work/application")
+                            .withArgs("--sauce=" + sauce, "--toppings=" + String.join(",", toppings));
+                    final PodSpecBuilder podSpecBuilder = new PodSpecBuilder().withContainers(containerBuilder.build())
+                            .withRestartPolicy("Never");
+                    final PodBuilder podBuilder = new PodBuilder().withMetadata(objectMetaBuilder.build())
+                            .withSpec(podSpecBuilder.build());
+                    final Pod pod = podBuilder.build();
+                    defaultClient.resource(pod).createOrReplace();
+
+                }
+            }
+
+            @Override
+            public void onClose(KubernetesClientException e) {
+            }
+        });
+    }
+
+}

--- a/documentation/modules/ROOT/examples/cheese-pizza.yaml
+++ b/documentation/modules/ROOT/examples/cheese-pizza.yaml
@@ -1,1 +1,0 @@
-/workspaces/kubernetes-tutorial/apps/pizzas/cheese-pizza.yaml

--- a/documentation/modules/ROOT/examples/meat-pizza.yaml
+++ b/documentation/modules/ROOT/examples/meat-pizza.yaml
@@ -1,1 +1,11 @@
-/workspaces/kubernetes-tutorial/apps/pizzas/meat-pizza.yaml
+apiVersion: mykubernetes.acme.org/v1
+kind: Pizza
+metadata:
+  name: meatsp
+spec:
+  toppings:
+  - mozzarella
+  - pepperoni
+  - sausage
+  - bacon
+  sauce: extra

--- a/documentation/modules/ROOT/examples/myboot-deployment-configuration-secret.yml
+++ b/documentation/modules/ROOT/examples/myboot-deployment-configuration-secret.yml
@@ -1,1 +1,36 @@
-/workspaces/kubernetes-tutorial/apps/kubefiles/myboot-deployment-configuration-secret.yml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: myboot
+  name: myboot
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: myboot
+  template:
+    metadata:
+      labels:
+        app: myboot
+    spec:
+      containers:
+      - name: myboot
+        image: quay.io/rhdevelopers/myboot:v1
+        ports:
+          - containerPort: 8080
+        volumeMounts:          
+          - name: mysecretvolume #<.>
+            mountPath: /mystuff/secretstuff
+            readOnly: true
+        resources:
+          requests: 
+            memory: "300Mi" 
+            cpu: "250m" # 1/4 core
+          limits:
+            memory: "400Mi"
+            cpu: "1000m" # 1 core
+      volumes:
+        - name: mysecretvolume #<.>
+          secret:
+            secretName: mysecret

--- a/documentation/modules/ROOT/examples/myboot-deployment-live-ready-aggressive.yml
+++ b/documentation/modules/ROOT/examples/myboot-deployment-live-ready-aggressive.yml
@@ -1,1 +1,40 @@
-/workspaces/kubernetes-tutorial/apps/kubefiles/myboot-deployment-live-ready-aggressive.yml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: myboot
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: myboot
+  template:
+    metadata:
+      labels:
+        app: myboot
+        env: dev
+    spec:
+      containers:
+      - name: myboot
+        image: quay.io/rhdevelopers/myboot:v1
+        imagePullPolicy: Always
+        ports:
+        - containerPort: 8080
+        resources:
+          requests:
+            memory: "300Mi"
+            cpu: "250m" # 1/4 core
+          limits:
+            memory: "400Mi"
+            cpu: "1000m" # 1 core
+        livenessProbe:
+          httpGet:
+              port: 8080
+              path: /alive
+          periodSeconds: 2
+          timeoutSeconds: 2
+          failureThreshold: 2
+        readinessProbe:
+          httpGet:
+            path: /health
+            port: 8080
+          periodSeconds: 3

--- a/documentation/modules/ROOT/examples/myboot-deployment-live-ready.yml
+++ b/documentation/modules/ROOT/examples/myboot-deployment-live-ready.yml
@@ -1,1 +1,41 @@
-/workspaces/kubernetes-tutorial/apps/kubefiles/myboot-deployment-live-ready.yml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: myboot
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: myboot
+  template:
+    metadata:
+      labels:
+        app: myboot
+        env: dev
+    spec:
+      containers:
+      - name: myboot
+        image: quay.io/rhdevelopers/myboot:v1
+        imagePullPolicy: Always
+        ports:
+        - containerPort: 8080
+        resources:
+          requests:
+            memory: "300Mi"
+            cpu: "250m" # 1/4 core
+          limits:
+            memory: "400Mi"
+            cpu: "1000m" # 1 core
+        livenessProbe:
+          httpGet:
+              port: 8080
+              path: /alive
+          initialDelaySeconds: 10
+          periodSeconds: 5
+          timeoutSeconds: 2
+        readinessProbe:
+          httpGet:  
+            path: /health
+            port: 8080
+          initialDelaySeconds: 10
+          periodSeconds: 3

--- a/documentation/modules/ROOT/examples/myboot-deployment-startup-live-ready.yml
+++ b/documentation/modules/ROOT/examples/myboot-deployment-startup-live-ready.yml
@@ -1,1 +1,47 @@
-/workspaces/kubernetes-tutorial/apps/kubefiles/myboot-deployment-startup-live-ready.yml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: myboot
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: myboot
+  template:
+    metadata:
+      labels:
+        app: myboot
+        env: dev
+    spec:
+      containers:
+      - name: myboot
+        image: quay.io/rhdevelopers/myboot:v1
+        imagePullPolicy: Always
+        ports:
+        - containerPort: 8080
+        resources:
+          requests:
+            memory: "300Mi"
+            cpu: "250m" # 1/4 core
+          limits:
+            memory: "400Mi"
+            cpu: "1000m" # 1 core
+        livenessProbe:
+          httpGet:
+              port: 8080
+              path: /alive
+          periodSeconds: 2
+          timeoutSeconds: 2
+          failureThreshold: 2
+        readinessProbe:
+          httpGet:
+            path: /health
+            port: 8080
+          periodSeconds: 3
+        startupProbe:
+          httpGet:
+            path: /alive
+            port: 8080
+          failureThreshold: 6
+          periodSeconds: 5
+          timeoutSeconds: 1

--- a/documentation/modules/ROOT/examples/myboot-pod-volume-hostpath.yaml
+++ b/documentation/modules/ROOT/examples/myboot-pod-volume-hostpath.yaml
@@ -1,1 +1,17 @@
-/workspaces/kubernetes-tutorial/apps/kubefiles/myboot-pod-volume-hostpath.yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: myboot-demo
+spec:
+  containers:
+  - name: myboot-demo
+    image: quay.io/rhdevelopers/myboot:v4
+    
+    volumeMounts:
+    - mountPath: /tmp/demo
+      name: demo-volume
+
+  volumes:
+  - name: demo-volume
+    hostPath: #<.> 
+      path: "/mnt/data" #<.>

--- a/documentation/modules/ROOT/examples/myboot-pod-volume.yml
+++ b/documentation/modules/ROOT/examples/myboot-pod-volume.yml
@@ -1,1 +1,16 @@
-/workspaces/kubernetes-tutorial/apps/kubefiles/myboot-pod-volume.yml
+apiVersion: v1
+kind: Pod #<.>
+metadata:
+  name: myboot-demo
+spec:
+  containers:
+  - name: myboot-demo
+    image: quay.io/rhdevelopers/myboot:v4
+    
+    volumeMounts:
+    - mountPath: /tmp/demo #<.>
+      name: demo-volume #<.> 
+
+  volumes:
+  - name: demo-volume
+    emptyDir: {}

--- a/documentation/modules/ROOT/examples/myboot-pods-volume.yml
+++ b/documentation/modules/ROOT/examples/myboot-pods-volume.yml
@@ -1,1 +1,26 @@
-/workspaces/kubernetes-tutorial/apps/kubefiles/myboot-pods-volume.yml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: myboot-demo
+spec:
+  containers:
+  - name: myboot-demo-1 #<.>
+    image: quay.io/rhdevelopers/myboot:v4
+    volumeMounts:
+    - mountPath: /tmp/demo
+      name: demo-volume
+
+  - name: myboot-demo-2 #<.>
+    image: quay.io/rhdevelopers/myboot:v4 #<.>
+
+    env:
+    - name: SERVER_PORT #<.>
+      value: "8090"
+
+    volumeMounts:
+    - mountPath: /tmp/demo
+      name: demo-volume
+
+  volumes:
+  - name: demo-volume #<.>
+    emptyDir: {}

--- a/documentation/modules/ROOT/examples/pizza-crd.yaml
+++ b/documentation/modules/ROOT/examples/pizza-crd.yaml
@@ -1,1 +1,38 @@
-/workspaces/kubernetes-tutorial/apps/pizzas/pizza-crd.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: pizzas.mykubernetes.acme.org
+  labels:
+    app: pizzamaker
+    mylabel: stuff
+spec:
+  group: mykubernetes.acme.org
+  scope: Namespaced
+  versions:
+  - name: v1
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        description: "A custom resource for making yummy pizzas" #<.>
+        type: object
+        properties:
+          spec:
+            type: object
+            description: "Information about our pizza"
+            properties:
+              toppings: #<.>
+                type: array
+                items:
+                  type: string
+                description: "List of toppings for our pizza"
+              sauce: #<.>
+                type: string
+                description: "The name of the sauce to use on our pizza"
+  names:
+    kind: Pizza #<.>
+    listKind: PizzaList
+    plural: pizzas
+    singular: pizza
+    shortNames:
+    - pz

--- a/documentation/modules/ROOT/examples/quarkus-statefulset-external-svc.yaml
+++ b/documentation/modules/ROOT/examples/quarkus-statefulset-external-svc.yaml
@@ -1,1 +1,12 @@
-/workspaces/kubernetes-tutorial/apps/kubefiles/quarkus-statefulset-external-svc.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: quarkus-statefulset-2
+spec:
+  type: LoadBalancer #<.>
+  externalTrafficPolicy: Local #<.>
+  selector:
+    statefulset.kubernetes.io/pod-name: quarkus-statefulset-2 #<.>
+  ports:
+  - port: 8080
+    name: web

--- a/documentation/modules/ROOT/examples/whalesay-cronjob.yaml
+++ b/documentation/modules/ROOT/examples/whalesay-cronjob.yaml
@@ -1,1 +1,18 @@
-/workspaces/kubernetes-tutorial/apps/kubefiles/whalesay-cronjob.yaml
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: whale-say-cronjob
+spec:
+  schedule: "*/1 * * * *" #<.>
+  jobTemplate:                   
+    spec:                        
+      template:    
+        metadata:
+          labels:
+            job-type: whale-say #<.>              
+        spec:
+          containers:
+          - name: whale-say-container
+            image: docker/whalesay
+            command: ["cowsay","Hello DevNation"]
+          restartPolicy: Never

--- a/documentation/modules/ROOT/examples/whalesay-job.yaml
+++ b/documentation/modules/ROOT/examples/whalesay-job.yaml
@@ -1,1 +1,12 @@
-/workspaces/kubernetes-tutorial/apps/kubefiles/whalesay-job.yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: whale-say-job #<.>
+spec:
+  template:
+    spec:
+      containers:
+      - name: whale-say-container
+        image: docker/whalesay
+        command: ["cowsay","Hello DevNation"]
+      restartPolicy: Never

--- a/documentation/modules/ROOT/pages/_attributes.adoc
+++ b/documentation/modules/ROOT/pages/_attributes.adoc
@@ -1,6 +1,6 @@
 :moduledir: ..
 :branch: master
-:github-repo: https://github.com/redhat-developer-demos/kubernetes-tutorial
+:github-repo: https://github.com/redhat-scholars/kubernetes-tutorial
 :openshift-version: 4.3
 :vm-driver: virtualbox
 :profile: devnation

--- a/documentation/modules/ROOT/pages/blue-green.adoc
+++ b/documentation/modules/ROOT/pages/blue-green.adoc
@@ -1,6 +1,6 @@
 = Blue/Green
 
-https://martinfowler.com/bliki/BlueGreenDeployment.html[Description of Blue/Green Deployment]
+https://martinfowler.com/bliki/BlueGreenDeployment.html[Here] you can find a description and history of Blue/Green Deployment.
 
 Make sure you are in the correct namespace
 

--- a/documentation/modules/ROOT/pages/crds.adoc
+++ b/documentation/modules/ROOT/pages/crds.adoc
@@ -162,10 +162,10 @@ include::partial$tip_vscode_quick_open.adoc[]
 ----
 include::example$pizza-crd.yaml[]
 ----
-<.> This is a description that will be shown when somebody attempts to describe the CRD
-<.> This describes one of the values our `CustomResource` will have, namely, the (`array`) list of (`string`) toppings
-<.> This describes the second field our `CustomResource` can define in its spec, the (`string`) name of the sauce to use
-<.> This is the name that our CustomResources will have.  Sort of like `Deployment` or `Pod`
+<1> This is a description that will be shown when somebody attempts to describe the CRD
+<2> This describes one of the values our `CustomResource` will have, namely, the (`array`) list of (`string`) toppings
+<3> This describes the second field our `CustomResource` can define in its spec, the (`string`) name of the sauce to use
+<4> This is the name that our CustomResources will have.  Sort of like `Deployment` or `Pod`
 
 [IMPORTANT]
 ====

--- a/documentation/modules/ROOT/pages/resources.adoc
+++ b/documentation/modules/ROOT/pages/resources.adoc
@@ -190,24 +190,16 @@ You can also use `kubectl describe` on the pod to find more information about th
 :label-describe: app=myboot
 include::partial$describe.adoc[]
 
-Delete the deployment:
-
-[#delete-deployment-limit-resource]
-[.console-input]
-[source, bash]
-----
-kubectl delete -f apps/kubefiles/myboot-deployment-resources.yml
-----
-
-Create a new deployment with a more sane resource request and a hard limit:
+We should fix the deployment while keeping a history of changes done by `replace`:
 
 [#apply-deployment-sane-limit-resource]
 [.console-input]
 [source, bash]
 ----
-kubectl apply -f apps/kubefiles/myboot-deployment-resources-limits.yml
+kubectl replace -f apps/kubefiles/myboot-deployment-resources-limits.yml
 ----
 
+The above command will replace the Deployment template and instruct the Pod to have container limits.
 Describe the Pod:
 
 :section-k8s: resource-soft-limit
@@ -254,7 +246,7 @@ NOTE: The reported memory vs what was set in the resource limits
 [source, bash]
 ----
 PODNAME=$(kubectl get pod -l app=myboot -o name)
-kubectl get $PODNAME -o json | jq ".spec.containers[0].resources"
+kubectl get $PODNAME -o jsonpath='{.spec.containers[*].resources}'
 ----
 
 [.console-output]
@@ -316,7 +308,7 @@ And look for the following part:
 [.console-input]
 [source, bash]
 ----
-kubectl get $PODNAME -o json | jq ".status.containerStatuses[0].lastState.terminated"
+ kubectl get $PODNAME -o jsonpath='{.status.containerStatuses[0].lastState.terminated'}
 ----
 
 [.console-output]

--- a/documentation/modules/ROOT/pages/rolling-updates.adoc
+++ b/documentation/modules/ROOT/pages/rolling-updates.adoc
@@ -6,9 +6,10 @@ Make sure you are in the correct namespace
 :set-namespace: myspace
 include::partial$set-context.adoc[]
 
-.TIP
-****
+[TIP,subs="attributes+,+macros"]
+====
 If you just came from xref::resources.adoc[the Resources and Limits section, window=_blank] then you should already have the pods and deployments active that you need.  If not, you will need run the following commands to deploy the needed elements into {set-namespace}
+====
 
 Deploy the Spring Boot app if needed:
 
@@ -34,9 +35,8 @@ And run loop script:
 
 include::partial$loop.adoc[]
 
-****
 
-*Terminal 3*: Run commands.
+*Terminal 3* : Run commands.
 
 Describe (or `kubectl edit`) the Deployment:
 
@@ -236,13 +236,21 @@ Events:
   Normal  ScalingReplicaSet  2m37s  deployment-controller  Scaled down replica set myboot-d78fb6d58 to 0
 ----
 
-Rollback to v1:
+You can list the revisions associated to your deployment by running the following command:
+[#rollout-history]
+[.console-input]
+[source, bash]
+----
+kubectl rollout history deployment/myboot
+----
+
+You can rollback to v1 using the following command:
 
 [#describe-rollback-rolling]
 [.console-input]
 [source, bash]
 ----
-kubectl set image deployment myboot myboot=quay.io/rhdevelopers/myboot:v1
+kubectl rollout undo deployment/myboot --to-revision=1
 ----
 
 And it rolls back to Aloha:

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "quarkus-tutorial-site",
-  "description": "Quarkus Tutorial Documentation",
-  "homepage": "https://redhat-developer-demos.github.io/quarkus-tutorial",
+  "name": "kubernetes-tutorial-site",
+  "description": "Kubernetes Tutorial Documentation",
+  "homepage": "https://redhat-scholars.github.io/kubernetes-tutorial",
   "author": {
     "email": "kamesh.sampath@hotmail.com",
     "name": "Kamesh Sampath",
@@ -28,7 +28,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/redhat-developer-demos/quarkus-tutorial.git"
+    "url": "git+https://github.com/redhat-scholars/kubernetes-tutorial.git"
   },
   "license": "Apache-2.0",
   "babel": {


### PR DESCRIPTION
Things changed/added:
1. Minor fixes on unclosed tags.
2. Command to see rollout history and rollback to a revision 
3. 'replace' instead of `apply` to keep a history of changes done on the same Deployment resource
4. Added JRE as FROM for the image instead of JDK - the image will be slimmer.