### PR TITLE
Update to newer Ingress API version

### DIFF
--- a/documentation/modules/ROOT/pages/service.adoc
+++ b/documentation/modules/ROOT/pages/service.adoc
@@ -126,7 +126,7 @@ NOTE: "5979886fb7-grf59" is part of the unique id for the pod. The `.java` code 
 [source,bash,subs="+macros,+attributes"]
 ----
 cat <<EOF | kubectl apply -f -
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: myingress
@@ -136,9 +136,12 @@ spec:
     http:
       paths:
       - path: /
+        pathType: Prefix
         backend:
-          serviceName: the-service
-          servicePort: 80
+          service:
+            name: the-service
+            port:
+              number: 80
 EOF          
 ----
 


### PR DESCRIPTION
The networking.k8s.io/v1beta1 API versions of Ingress is not longer served as of v1.22 (see https://kubernetes.io/docs/reference/using-api/deprecation-guide/#ingress-v122). Migrate to newer version.