### PR TITLE
Update statefulset.adoc

### DIFF
--- a/documentation/modules/ROOT/pages/statefulset.adoc
+++ b/documentation/modules/ROOT/pages/statefulset.adoc
@@ -61,6 +61,9 @@ metadata:
 spec:
   serviceName: "quarkus" # <.>
   replicas: 2
+  selector:
+    matchLabels:
+      app: quarkus-statefulset
   template:
     metadata:
       labels:


### PR DESCRIPTION
Fixing following error message:

The StatefulSet "quarkus-statefulset" is invalid:
* spec.selector: Required value
* spec.template.metadata.labels: Invalid value: map[string]string{"app":"quarkus-statefulset"}: `selector` does not match template `labels`